### PR TITLE
Separate crates and complete rename

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -164,19 +164,19 @@ dependencies = [
 
 [[package]]
 name = "corewars-core"
-version = "0.1.0"
+version = "0.0.0"
 
 [[package]]
 name = "corewars-parser"
-version = "0.1.0"
+version = "0.0.0"
 
 [[package]]
 name = "corewars-sim"
-version = "0.1.0"
+version = "0.0.0"
 
 [[package]]
 name = "corewars-wasm"
-version = "0.1.0"
+version = "0.0.0"
 
 [[package]]
 name = "crossbeam-utils"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -163,6 +163,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "corewars-core"
+version = "0.1.0"
+
+[[package]]
+name = "corewars-parser"
+version = "0.1.0"
+
+[[package]]
+name = "corewars-sim"
+version = "0.1.0"
+
+[[package]]
+name = "corewars-wasm"
+version = "0.1.0"
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,8 @@
 [workspace]
 members = [
     "corewars",
+    "corewars-core",
+    "corewars-parser",
+    "corewars-sim",
+    "corewars-wasm",
 ]

--- a/corewars-core/Cargo.toml
+++ b/corewars-core/Cargo.toml
@@ -1,9 +1,8 @@
 [package]
 name = "corewars-core"
-version = "0.1.0"
-authors = ["Ian Chamberlain <ian.h.chamberlain@gmail.com>"]
+version = "0.0.0"
+authors = ["Ian Chamberlain <ian@corewa.rs>"]
 edition = "2018"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
-[dependencies]
+description = "A placeholder subcrate for corewars"
+license = "MIT"
+repository = "https://github.com/corewa-rs/corewars"

--- a/corewars-core/Cargo.toml
+++ b/corewars-core/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "corewars-core"
+version = "0.1.0"
+authors = ["Ian Chamberlain <ian.h.chamberlain@gmail.com>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/corewars-core/src/lib.rs
+++ b/corewars-core/src/lib.rs
@@ -1,0 +1,7 @@
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn it_works() {
+        assert_eq!(2 + 2, 4);
+    }
+}

--- a/corewars-parser/Cargo.toml
+++ b/corewars-parser/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "corewars-parser"
+version = "0.1.0"
+authors = ["Ian Chamberlain <ian.h.chamberlain@gmail.com>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/corewars-parser/Cargo.toml
+++ b/corewars-parser/Cargo.toml
@@ -1,9 +1,8 @@
 [package]
 name = "corewars-parser"
-version = "0.1.0"
-authors = ["Ian Chamberlain <ian.h.chamberlain@gmail.com>"]
+version = "0.0.0"
+authors = ["Ian Chamberlain <ian@corewa.rs>"]
 edition = "2018"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
-[dependencies]
+description = "A placeholder subcrate for corewars"
+license = "MIT"
+repository = "https://github.com/corewa-rs/corewars"

--- a/corewars-parser/src/lib.rs
+++ b/corewars-parser/src/lib.rs
@@ -1,0 +1,7 @@
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn it_works() {
+        assert_eq!(2 + 2, 4);
+    }
+}

--- a/corewars-sim/Cargo.toml
+++ b/corewars-sim/Cargo.toml
@@ -1,9 +1,8 @@
 [package]
 name = "corewars-sim"
-version = "0.1.0"
-authors = ["Ian Chamberlain <ian.h.chamberlain@gmail.com>"]
+version = "0.0.0"
+authors = ["Ian Chamberlain <ian@corewa.rs>"]
 edition = "2018"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
-[dependencies]
+description = "A placeholder subcrate for corewars"
+license = "MIT"
+repository = "https://github.com/corewa-rs/corewars"

--- a/corewars-sim/Cargo.toml
+++ b/corewars-sim/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "corewars-sim"
+version = "0.1.0"
+authors = ["Ian Chamberlain <ian.h.chamberlain@gmail.com>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/corewars-sim/src/lib.rs
+++ b/corewars-sim/src/lib.rs
@@ -1,0 +1,7 @@
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn it_works() {
+        assert_eq!(2 + 2, 4);
+    }
+}

--- a/corewars-wasm/Cargo.toml
+++ b/corewars-wasm/Cargo.toml
@@ -1,9 +1,8 @@
 [package]
 name = "corewars-wasm"
-version = "0.1.0"
-authors = ["Ian Chamberlain <ian.h.chamberlain@gmail.com>"]
+version = "0.0.0"
+authors = ["Ian Chamberlain <ian@corewa.rs>"]
 edition = "2018"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
-[dependencies]
+description = "A placeholder subcrate for corewars"
+license = "MIT"
+repository = "https://github.com/corewa-rs/corewars"

--- a/corewars-wasm/Cargo.toml
+++ b/corewars-wasm/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "corewars-wasm"
+version = "0.1.0"
+authors = ["Ian Chamberlain <ian.h.chamberlain@gmail.com>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/corewars-wasm/src/lib.rs
+++ b/corewars-wasm/src/lib.rs
@@ -1,0 +1,7 @@
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn it_works() {
+        assert_eq!(2 + 2, 4);
+    }
+}

--- a/corewars/Cargo.toml
+++ b/corewars/Cargo.toml
@@ -1,7 +1,14 @@
 [package]
-authors = ["Ian Chamberlain <ian.h.chamberlain@gmail.com>"]
+authors = ["Ian Chamberlain <ian@corewa.rs>"]
+categories = ["games", "emulators"]
+description = "The classic programming battle game Core Wars"
+homepage = "https://corewa.rs/"
 edition = "2018"
+keywords = ["corewars", "core", "war", "wars", "redcode"]
+license = "MIT"
 name = "corewars"
+readme = "../README.md"
+repository = "https://github.com/corewa-rs/corewars"
 version = "0.1.0"
 
 [dependencies]

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,7 +2,7 @@
 
 [![Latest Crates.io Release](https://img.shields.io/crates/v/corewars?label=corewars&logo=rust)](https://crates.io/crates/corewars)
 [![Latest Release](https://img.shields.io/github/v/release/corewa-rs/corewars?label=latest%20release&include_prereleases&logo=github)](https://github.com/corewa-rs/corewars/releases)
-[![Build Status](https://img.shields.io/github/workflow/status/corewa-rs/corewars/corewars/develop)](https://github.com/corewa-rs/corewars/actions)
+[![Build Status](https://img.shields.io/github/workflow/status/corewa-rs/corewars/ci/develop)](https://github.com/corewa-rs/corewars/actions)
 
 A Rust implementation of [Core Wars](http://www.koth.org/index.html).
 


### PR DESCRIPTION
First half or so of #42 

This can be used to publish the `corewars` crate, and some stub crates should be 