### PR TITLE
ian/pedantic-clippy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,8 +27,7 @@ jobs:
       - name: Run clippy linting
         run: cargo clippy --color=always --workspace --verbose --all-targets
         env:
-          RUSTFLAGS:
-            "-D warnings"
+          RUSTFLAGS: "--deny=warnings --deny=clippy::pedantic"
 
   validate:
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,12 @@ jobs:
       - name: Run clippy linting
         run: cargo clippy --color=always --workspace --verbose --all-targets
         env:
-          RUSTFLAGS: "--deny=warnings --deny=clippy::pedantic"
+          # TODO: fix cast warnings
+          RUSTFLAGS:
+            --deny=warnings
+            --deny=clippy::pedantic
+            --allow=clippy::cast_possible_wrap
+            --allow=clippy::cast_possible_truncation
 
   validate:
     strategy:

--- a/corewars-core/src/lib.rs
+++ b/corewars-core/src/lib.rs
@@ -1,3 +1,6 @@
+// TODO(#43): include these
+#![allow(clippy::missing_panics_doc)]
+
 // Macro-exporting modules
 #[macro_use]
 mod util;

--- a/corewars-core/src/load_file.rs
+++ b/corewars-core/src/load_file.rs
@@ -42,11 +42,13 @@ impl fmt::Display for Warrior {
 
 impl Warrior {
     /// The number of instrcutions defined in this Warrior's code
+    #[must_use]
     pub fn len(&self) -> u32 {
         self.program.instructions.len() as u32
     }
 
     /// Whether the warrior's program is empty (i.e. 0 instructions)
+    #[must_use]
     pub fn is_empty(&self) -> bool {
         self.program.instructions.is_empty()
     }
@@ -69,6 +71,7 @@ impl fmt::Display for Field {
 }
 
 impl Field {
+    #[must_use]
     pub fn direct(value: i32) -> Self {
         Self {
             address_mode: AddressMode::Direct,
@@ -83,6 +86,7 @@ impl Field {
         }
     }
 
+    #[must_use]
     pub fn immediate(value: i32) -> Self {
         Self {
             address_mode: AddressMode::Immediate,
@@ -90,10 +94,12 @@ impl Field {
         }
     }
 
+    #[must_use]
     pub fn unwrap_value(&self) -> i32 {
         self.value.unwrap()
     }
 
+    #[must_use]
     pub fn as_offset(&self, core_size: u32) -> Offset {
         Offset::new(self.unwrap_value(), core_size)
     }
@@ -112,6 +118,7 @@ pub struct Instruction {
 }
 
 impl Instruction {
+    #[must_use]
     pub fn new(opcode: Opcode, a_field: Field, b_field: Field) -> Self {
         let modifier =
             Modifier::default_88_to_94(opcode, a_field.address_mode, b_field.address_mode);

--- a/corewars-core/src/load_file.rs
+++ b/corewars-core/src/load_file.rs
@@ -1,4 +1,4 @@
-use std::fmt;
+use std::{convert::TryInto, fmt};
 
 use lazy_static::lazy_static;
 use maplit::hashmap;
@@ -41,10 +41,10 @@ impl fmt::Display for Warrior {
 }
 
 impl Warrior {
-    /// The number of instrcutions defined in this Warrior's code
+    /// The number of instructions defined in this Warrior's code
     #[must_use]
-    pub fn len(&self) -> u32 {
-        self.program.instructions.len() as u32
+    pub fn len(&self) -> usize {
+        self.program.instructions.len()
     }
 
     /// Whether the warrior's program is empty (i.e. 0 instructions)
@@ -79,7 +79,7 @@ impl Field {
         }
     }
 
-    pub fn direct_label<S: ToString>(label: S) -> Self {
+    pub fn direct_label<S: ToString>(label: &S) -> Self {
         Self {
             address_mode: AddressMode::Direct,
             value: Value::Label(label.to_string()),
@@ -105,7 +105,12 @@ impl Field {
     }
 
     pub fn set_value(&mut self, offset: Offset) {
-        self.value = Value::Literal(offset.value() as i32)
+        self.value = Value::Literal(
+            offset
+                .value()
+                .try_into()
+                .expect("Offset should always be convertible to i32"),
+        );
     }
 }
 
@@ -165,6 +170,6 @@ mod test {
             },
         };
 
-        assert_eq!(Instruction::default(), expected_instruction)
+        assert_eq!(Instruction::default(), expected_instruction);
     }
 }

--- a/corewars-core/src/load_file/metadata.rs
+++ b/corewars-core/src/load_file/metadata.rs
@@ -34,7 +34,7 @@ impl Metadata {
     /// Parse warrior metadata out of a line. Any comments will be removed and
     /// the resulting string returned, with whitespace trimmed.
     pub fn parse_line(&mut self, line: &str) -> String {
-        let split_line: Vec<&str> = line.splitn(2, ';').map(|p| p.trim()).collect();
+        let split_line: Vec<&str> = line.splitn(2, ';').map(str::trim).collect();
 
         if split_line.len() > 1 {
             let split_comment: Vec<&str> = split_line[1].splitn(2, char::is_whitespace).collect();

--- a/corewars-core/src/load_file/offset.rs
+++ b/corewars-core/src/load_file/offset.rs
@@ -11,6 +11,7 @@ impl Offset {
     /// Create a new Offset. The value will be adjusted to be within bounds of the core.
     ///
     /// Panics if `core_size` is invalid. Both 0 and `u32::MAX` are disallowed.
+    #[must_use]
     pub fn new(value: i32, core_size: u32) -> Self {
         // TODO: should there be a minimum allowed core size?
         let core_isize = core_size as i32;
@@ -30,6 +31,7 @@ impl Offset {
     }
 
     /// Get the value of the offset. This will always be less than the core size.
+    #[must_use]
     pub fn value(&self) -> u32 {
         self.value
     }
@@ -150,17 +152,17 @@ mod tests {
     fn add_offset() {
         let mut offset = Offset::new(0, 12);
 
-        assert_eq!(offset + 17i32, Offset::new(5, 12));
-        assert_eq!(offset + -17i32, Offset::new(7, 12));
+        assert_eq!(offset + 17_i32, Offset::new(5, 12));
+        assert_eq!(offset + -17_i32, Offset::new(7, 12));
         assert_eq!(offset + Offset::new(17, 12), Offset::new(5, 12));
         assert_eq!(offset + Offset::new(-17, 12), Offset::new(7, 12));
-        assert_eq!(offset + 17u32, Offset::new(5, 12));
+        assert_eq!(offset + 17_u32, Offset::new(5, 12));
 
-        offset += 17i32;
+        offset += 17_i32;
         assert_eq!(offset, Offset::new(5, 12));
         offset = Offset::new(0, 12);
 
-        offset += -17i32;
+        offset += -17_i32;
         assert_eq!(offset, Offset::new(7, 12));
         offset = Offset::new(0, 12);
 
@@ -172,7 +174,7 @@ mod tests {
         assert_eq!(offset, Offset::new(7, 12));
         offset = Offset::new(0, 12);
 
-        offset += 17u32;
+        offset += 17_u32;
         assert_eq!(offset, Offset::new(5, 12));
     }
 
@@ -180,17 +182,17 @@ mod tests {
     fn sub_offset() {
         let mut offset = Offset::new(0, 12);
 
-        assert_eq!(offset - 17i32, Offset::new(7, 12));
-        assert_eq!(offset - -17i32, Offset::new(5, 12));
+        assert_eq!(offset - 17_i32, Offset::new(7, 12));
+        assert_eq!(offset - -17_i32, Offset::new(5, 12));
         assert_eq!(offset - Offset::new(17, 12), Offset::new(7, 12));
         assert_eq!(offset - Offset::new(-17, 12), Offset::new(5, 12));
-        assert_eq!(offset - 17u32, Offset::new(7, 12));
+        assert_eq!(offset - 17_u32, Offset::new(7, 12));
 
-        offset -= 17i32;
+        offset -= 17_i32;
         assert_eq!(offset, Offset::new(7, 12));
 
         offset = Offset::new(0, 12);
-        offset -= -17i32;
+        offset -= -17_i32;
         assert_eq!(offset, Offset::new(5, 12));
 
         offset = Offset::new(0, 12);
@@ -202,7 +204,7 @@ mod tests {
         assert_eq!(offset, Offset::new(5, 12));
 
         offset = Offset::new(0, 12);
-        offset -= 17u32;
+        offset -= 17_u32;
         assert_eq!(offset, Offset::new(7, 12));
     }
 
@@ -210,17 +212,17 @@ mod tests {
     fn mul_offset() {
         let mut offset = Offset::new(2, 12);
 
-        assert_eq!(offset * 5i32, Offset::new(10, 12));
-        assert_eq!(offset * -5i32, Offset::new(2, 12));
+        assert_eq!(offset * 5_i32, Offset::new(10, 12));
+        assert_eq!(offset * -5_i32, Offset::new(2, 12));
         assert_eq!(offset * Offset::new(5, 12), Offset::new(10, 12));
         assert_eq!(offset * Offset::new(-5, 12), Offset::new(2, 12));
-        assert_eq!(offset * 5u32, Offset::new(10, 12));
+        assert_eq!(offset * 5_u32, Offset::new(10, 12));
 
-        offset *= 5i32;
+        offset *= 5_i32;
         assert_eq!(offset, Offset::new(10, 12));
 
         offset = Offset::new(2, 12);
-        offset *= -5i32;
+        offset *= -5_i32;
         assert_eq!(offset, Offset::new(2, 12));
 
         offset = Offset::new(2, 12);
@@ -232,7 +234,7 @@ mod tests {
         assert_eq!(offset, Offset::new(2, 12));
 
         offset = Offset::new(2, 12);
-        offset *= 5u32;
+        offset *= 5_u32;
         assert_eq!(offset, Offset::new(10, 12));
     }
 
@@ -240,17 +242,17 @@ mod tests {
     fn div_offset() {
         let mut offset = Offset::new(10, 12);
 
-        assert_eq!(offset / 5i32, Offset::new(2, 12));
-        assert_eq!(offset / -5i32, Offset::new(1, 12));
+        assert_eq!(offset / 5_i32, Offset::new(2, 12));
+        assert_eq!(offset / -5_i32, Offset::new(1, 12));
         assert_eq!(offset / Offset::new(5, 12), Offset::new(2, 12));
         assert_eq!(offset / Offset::new(-5, 12), Offset::new(1, 12));
-        assert_eq!(offset / 5u32, Offset::new(2, 12));
+        assert_eq!(offset / 5_u32, Offset::new(2, 12));
 
-        offset /= 5i32;
+        offset /= 5_i32;
         assert_eq!(offset, Offset::new(2, 12));
 
         offset = Offset::new(10, 12);
-        offset /= -5i32;
+        offset /= -5_i32;
         assert_eq!(offset, Offset::new(1, 12));
 
         offset = Offset::new(10, 12);
@@ -262,7 +264,7 @@ mod tests {
         assert_eq!(offset, Offset::new(1, 12));
 
         offset = Offset::new(10, 12);
-        offset /= 5u32;
+        offset /= 5_u32;
         assert_eq!(offset, Offset::new(2, 12));
     }
 
@@ -270,17 +272,17 @@ mod tests {
     fn rem_offset() {
         let mut offset = Offset::new(8, 12);
 
-        assert_eq!(offset % 5i32, Offset::new(3, 12));
-        assert_eq!(offset % -5i32, Offset::new(1, 12));
+        assert_eq!(offset % 5_i32, Offset::new(3, 12));
+        assert_eq!(offset % -5_i32, Offset::new(1, 12));
         assert_eq!(offset % Offset::new(5, 12), Offset::new(3, 12));
         assert_eq!(offset % Offset::new(-5, 12), Offset::new(1, 12));
-        assert_eq!(offset % 5u32, Offset::new(3, 12));
+        assert_eq!(offset % 5_u32, Offset::new(3, 12));
 
-        offset %= 5i32;
+        offset %= 5_i32;
         assert_eq!(offset, Offset::new(3, 12));
 
         offset = Offset::new(8, 12);
-        offset %= -5i32;
+        offset %= -5_i32;
         assert_eq!(offset, Offset::new(1, 12));
 
         offset = Offset::new(8, 12);
@@ -292,7 +294,7 @@ mod tests {
         assert_eq!(offset, Offset::new(1, 12));
 
         offset = Offset::new(8, 12);
-        offset %= 5u32;
+        offset %= 5_u32;
         assert_eq!(offset, Offset::new(3, 12));
     }
 }

--- a/corewars-core/src/load_file/program.rs
+++ b/corewars-core/src/load_file/program.rs
@@ -20,6 +20,7 @@ pub struct Program {
 }
 
 impl Program {
+    #[must_use]
     pub fn get(&self, index: usize) -> Option<Instruction> {
         self.instructions.get(index).cloned()
     }
@@ -41,7 +42,7 @@ impl fmt::Debug for Program {
         let lines = self
             .instructions
             .iter()
-            .map(|s| s.to_string())
+            .map(std::string::ToString::to_string)
             .collect::<Vec<_>>();
 
         write!(formatter, "lines: {:#?},", lines)?;
@@ -60,7 +61,7 @@ impl fmt::Display for Program {
             self.origin.unwrap_or_default()
         ));
 
-        for instruction in self.instructions.iter() {
+        for instruction in &self.instructions {
             lines.push(instruction.to_string());
         }
 

--- a/corewars-core/src/load_file/types.rs
+++ b/corewars-core/src/load_file/types.rs
@@ -122,7 +122,7 @@ impl Value {
     pub fn unwrap(&self) -> i32 {
         match *self {
             Value::Literal(i32) => i32,
-            _ => panic!("unwrapped value of a Value without a literal i32"),
+            Value::Label(_) => panic!("unwrapped value of a Value without a literal i32"),
         }
     }
 }
@@ -168,10 +168,9 @@ mod test {
     }
 
     #[test]
-    fn modifier_b_default() {
-        let opcodes = [Mov, Cmp, Seq, Sne];
-
-        for (&opcode, &a_mode) in iproduct!(opcodes.iter(), AddressMode::iter_values()) {
+    fn modifier_b_immediate() {
+        let codes = [Mov, Cmp, Seq, Sne, Add, Sub, Mul, Div, Mod];
+        for (&opcode, &a_mode) in iproduct!(codes.iter(), AddressMode::iter_values()) {
             if a_mode != AddressMode::Immediate {
                 assert_eq!(
                     Modifier::default_88_to_94(opcode, a_mode, AddressMode::Immediate),
@@ -179,32 +178,27 @@ mod test {
                 );
             }
         }
+    }
 
-        let opcodes = [Add, Sub, Mul, Div, Mod];
-
-        for (&opcode, &a_mode) in iproduct!(opcodes.iter(), AddressMode::iter_values()) {
-            if a_mode != AddressMode::Immediate {
-                assert_eq!(
-                    Modifier::default_88_to_94(opcode, a_mode, AddressMode::Immediate),
-                    Modifier::B
-                );
-            }
-        }
-
+    #[test]
+    fn modifier_b_slt() {
         for (&a_mode, &b_mode) in iproduct!(AddressMode::iter_values(), AddressMode::iter_values())
         {
             if a_mode != AddressMode::Immediate {
                 assert_eq!(
                     Modifier::default_88_to_94(Opcode::Slt, a_mode, b_mode),
                     Modifier::B
-                )
+                );
             }
         }
+    }
 
-        let opcodes = [Jmp, Jmz, Jmn, Djn, Spl, Nop];
+    #[test]
+    fn modifier_b_all_modes() {
+        let codes = [Jmp, Jmz, Jmn, Djn, Spl, Nop];
 
         for (&opcode, &a_mode, &b_mode) in iproduct!(
-            opcodes.iter(),
+            codes.iter(),
             AddressMode::iter_values(),
             AddressMode::iter_values()
         ) {

--- a/corewars-core/src/load_file/types.rs
+++ b/corewars-core/src/load_file/types.rs
@@ -62,10 +62,13 @@ impl Default for Modifier {
 }
 
 impl Modifier {
+    #[must_use]
     pub fn default_88_to_94(opcode: Opcode, a_mode: AddressMode, b_mode: AddressMode) -> Self {
         /// Implemented based on the ICWS '94 document,
         /// section A.2.1.2: ICWS'88 to ICWS'94 Conversion
-        use Opcode::*;
+        use Opcode::{
+            Add, Cmp, Dat, Div, Djn, Jmn, Jmp, Jmz, Mod, Mov, Mul, Nop, Seq, Slt, Sne, Spl, Sub,
+        };
 
         match opcode {
             Dat => Modifier::F,
@@ -115,6 +118,7 @@ pub enum Value {
 }
 
 impl Value {
+    #[must_use]
     pub fn unwrap(&self) -> i32 {
         match *self {
             Value::Literal(i32) => i32,
@@ -150,7 +154,7 @@ mod test {
     use itertools::iproduct;
 
     use super::*;
-    use Opcode::*;
+    use Opcode::{Add, Cmp, Div, Djn, Jmn, Jmp, Jmz, Mod, Mov, Mul, Nop, Seq, Slt, Sne, Spl, Sub};
 
     #[test]
     fn dat_default() {

--- a/corewars-core/src/util.rs
+++ b/corewars-core/src/util.rs
@@ -64,7 +64,7 @@ macro_rules! enum_string {
 
         impl $name {
             #[allow(dead_code)]
-            pub fn iter_values() -> ::std::slice::Iter<'static, Self> {
+            #[must_use] pub fn iter_values() -> ::std::slice::Iter<'static, Self> {
                 const VALUES: &[$name] = &[$($name::$variant,)*];
                 VALUES.iter()
             }
@@ -127,7 +127,7 @@ mod test {
 
     #[test]
     fn iter_values() {
-        let values_from_iter: Vec<Foo> = Foo::iter_values().cloned().collect();
+        let values_from_iter: Vec<Foo> = Foo::iter_values().copied().collect();
         assert_eq!(
             values_from_iter,
             vec![Foo::Bar, Foo::Baz, Foo::SomethingElse]

--- a/corewars-parser/src/grammar.rs
+++ b/corewars-parser/src/grammar.rs
@@ -88,6 +88,8 @@ mod test {
         }) => {
             $(
                 for $value in [$($input,)*].iter() {
+                    // https://github.com/pest-parser/pest/issues/530
+                    #![allow(non_fmt_panic)]
                     parses_to! {
                         parser: Grammar,
                         input: $value,
@@ -100,6 +102,7 @@ mod test {
     }
 
     #[test]
+    #[allow(clippy::too_many_lines)]
     fn parse_expression() {
         match_parse!(Expression {
             "123" => [
@@ -346,11 +349,11 @@ mod test {
         });
     }
 
-    #[test_case("lbl", vec![(Label, "lbl")]; "label")]
-    #[test_case("lbl: ", vec![(Label, "lbl")]; "label with colon")]
+    #[test_case("lbl", &[(Label, "lbl")]; "label")]
+    #[test_case("lbl: ", &[(Label, "lbl")]; "label with colon")]
     #[test_case(
         "lbl: mov 0, 1",
-        vec![
+        &[
             (Label, "lbl"),
             (Opcode, "mov"),
             (Number, "0"),
@@ -360,35 +363,35 @@ mod test {
     )]
     #[test_case(
         "lbl equ 4",
-        vec![(Label, "lbl"), (Substitution, "4")];
+        &[(Label, "lbl"), (Substitution, "4")];
         "label equ expr"
     )]
     #[test_case(
         "lbl equ mov 1, 2",
-        vec![(Label, "lbl"), (Substitution, "mov 1, 2")];
+        &[(Label, "lbl"), (Substitution, "mov 1, 2")];
         "label equ instruction"
     )]
     #[test_case(
         "equ mov 1, 2",
-        vec![(Substitution, "mov 1, 2")];
+        &[(Substitution, "mov 1, 2")];
         "equ continuation"
     )]
     #[test_case(
         "equ mov 1, (1 + 2)",
-        vec![(Substitution, "mov 1, (1 + 2)")];
+        &[(Substitution, "mov 1, (1 + 2)")];
         "equ continuation expr"
     )]
     #[test_case(
         "for CORESIZE + 10",
-        vec![(For, "for"), (Label, "CORESIZE"), (AddOp, "+"), (Number, "10")];
+        &[(For, "for"), (Label, "CORESIZE"), (AddOp, "+"), (Number, "10")];
         "for statement"
     )]
     #[test_case(
         "N for CORESIZE + 10",
-        vec![(Label, "N"), (For, "for"), (Label, "CORESIZE"), (AddOp, "+"), (Number, "10")];
+        &[(Label, "N"), (For, "for"), (Label, "CORESIZE"), (AddOp, "+"), (Number, "10")];
         "for statement index"
     )]
-    fn tokenize_line(input: &str, expected_result: Vec<(Rule, &str)>) {
+    fn tokenize_line(input: &str, expected_result: &[(Rule, &str)]) {
         let actual: Vec<(Rule, &str)> = tokenize(input)
             .iter()
             .map(|pair| (pair.as_rule(), pair.as_str()))

--- a/corewars-parser/src/grammar.rs
+++ b/corewars-parser/src/grammar.rs
@@ -54,13 +54,11 @@ pub fn parse_expression(line: &str) -> Result<Pair, Error> {
 #[cfg(any(test, doctest))] // cfg(doctest) so we run the helper's doctest
 mod test {
     // pest::parses_to seems to have a panic that doesn't conform to rust 2021
-    #![allow(non_fmt_panic)]
-
     use pest::{consumes_to, parses_to};
     use test_case::test_case;
 
     use super::*;
-    use Rule::*;
+    use Rule::{AddOp, For, Label, Number, Opcode, Substitution};
 
     /// A macro to assert on the way a certain input string parses
     /// Two forms are allowed. One has no identifier:

--- a/corewars-parser/src/lib.rs
+++ b/corewars-parser/src/lib.rs
@@ -2,6 +2,9 @@
 //! It operates in multiple phases, which are found in the [phase](phase/index.html)
 //! module. Each phase passes its result to the next phase.
 
+// TODO(#43)
+#![allow(clippy::missing_panics_doc)]
+
 pub use error::{Error, Warning};
 pub use result::Result;
 

--- a/corewars-parser/src/phase.rs
+++ b/corewars-parser/src/phase.rs
@@ -101,7 +101,8 @@ impl TryFrom<Phase<Expanded>> for Phase<Evaluated> {
         let origin = prev
             .state
             .origin
-            .map(evaluation::evaluate_expression)
+            .as_ref()
+            .map(|s| evaluation::evaluate_expression(s))
             .transpose()?;
 
         // TODO evaluate assertions

--- a/corewars-parser/src/phase/comment.rs
+++ b/corewars-parser/src/phase/comment.rs
@@ -1,6 +1,6 @@
 //! In this phase, all comments are removed from the input phase.
 //! Any comments like `;redcode` and `;author` will be parsed and stored in
-//! load_file::Metadata. This phase also finds the origin and end of the program.
+//! [`Metadata`]. This phase also finds the origin and end of the program.
 
 use super::CommentsRemoved;
 
@@ -92,13 +92,9 @@ fn find_origin_in_line(line: &str) -> Result<OriginInLine, ()> {
                         Err(())
                     }
                 }
-                "END" => {
-                    if let Some(remainder) = remainder {
-                        Ok(EndWithNewOrigin(remainder.to_owned()))
-                    } else {
-                        Ok(End)
-                    }
-                }
+                "END" => remainder.map_or(Ok(End), |remainder| {
+                    Ok(EndWithNewOrigin(remainder.to_owned()))
+                }),
                 _ => Ok(NotFound),
             }
         }
@@ -108,6 +104,8 @@ fn find_origin_in_line(line: &str) -> Result<OriginInLine, ()> {
 
 #[cfg(test)]
 mod test {
+    #![allow(clippy::default_trait_access)]
+
     use test_case::test_case;
     use textwrap_macros::dedent;
 
@@ -119,7 +117,7 @@ mod test {
     }
 
     #[test_case(
-        Param {
+        &Param {
             input: dedent!(
                 "
                   foo who
@@ -138,7 +136,7 @@ mod test {
         "no comments"
     )]
     #[test_case(
-        Param {
+        &Param {
             input: dedent!(
                 "foo who
                 ; bar di bar
@@ -155,7 +153,7 @@ mod test {
         "remove comments"
     )]
     #[test_case(
-        Param {
+        &Param {
             input: dedent!(
                 "
                 ;redcode
@@ -177,7 +175,7 @@ mod test {
         "parse info comments"
     )]
     #[test_case(
-        Param {
+        &Param {
             input: dedent!(
                 "
                 ORG 5
@@ -196,7 +194,7 @@ mod test {
         "parse ORG"
     )]
     #[test_case(
-        Param {
+        &Param {
             input: dedent!(
                 "
                 ORG lbl1
@@ -215,7 +213,7 @@ mod test {
         "parse ORG label"
     )]
     #[test_case(
-        Param {
+        &Param {
             input: dedent!(
                 "
                 ORG lbl1 + 1
@@ -234,7 +232,7 @@ mod test {
         "parse ORG expression"
     )]
     #[test_case(
-        Param {
+        &Param {
             input: dedent!(
                 "
                 ORG 5
@@ -251,7 +249,7 @@ mod test {
         "parse multiple ORG"
     )]
     #[test_case(
-        Param {
+        &Param {
             input: dedent!(
                 "
                 org 5
@@ -267,7 +265,7 @@ mod test {
         "parse ORG and END"
     )]
     #[test_case(
-        Param {
+        &Param {
             input: dedent!(
                 "
                 MOV 1, 1
@@ -284,7 +282,7 @@ mod test {
         "parse END"
     )]
     #[test_case(
-        Param {
+        &Param {
             input: dedent!(
                 "
                 MOV 1, 1
@@ -302,7 +300,7 @@ mod test {
         "parse multiple END"
     )]
     #[test_case(
-        Param {
+        &Param {
             input: dedent!(
                 "
                 ; no real data in this input
@@ -312,13 +310,14 @@ mod test {
         };
         "empty result"
     )]
-    fn parse(param: Param) {
+    fn parse(param: &Param) {
         let result = extract_from_string(param.input);
 
         assert_eq!(result, param.expected);
     }
+
     #[test_case(
-        Param {
+        &Param {
             input: dedent!(
                 "
                 ORG
@@ -332,7 +331,7 @@ mod test {
         };
         "inconclusive(should error): parse ORG without arg"
     )]
-    fn parse_error(param: Param) {
+    fn parse_error(param: &Param) {
         let result = extract_from_string(param.input);
 
         assert_eq!(result, param.expected);

--- a/corewars-parser/src/phase/comment.rs
+++ b/corewars-parser/src/phase/comment.rs
@@ -67,7 +67,7 @@ pub fn extract_from_string(input: &str) -> CommentsRemoved {
 
 /// Find and return the origin defined in the given line.
 fn find_origin_in_line(line: &str) -> Result<OriginInLine, ()> {
-    use OriginInLine::*;
+    use OriginInLine::{End, EndWithNewOrigin, NewOrigin, NotFound};
 
     let tokenized = grammar::tokenize(line);
 

--- a/corewars-parser/src/phase/evaluation.rs
+++ b/corewars-parser/src/phase/evaluation.rs
@@ -30,14 +30,15 @@ pub fn evaluate(lines: Vec<String>) -> Result<load_file::Instructions, Error> {
 
 /// Parse and evaluate a single expression string to find the entry point to
 /// a warrior.
-pub fn evaluate_expression(expr: String) -> Result<u32, Error> {
-    let expr_pair = grammar::parse_expression(&expr)?;
+pub fn evaluate_expression(expr: &str) -> Result<u32, Error> {
+    let expr_pair = grammar::parse_expression(expr)?;
 
     let origin = expression::evaluate(expr_pair);
 
     Ok(u32::try_from(origin)?)
 }
 
+#[allow(clippy::option_if_let_else)] // TODO
 fn parse_instruction(
     mut instruction_pairs: grammar::Pairs,
 ) -> Result<load_file::Instruction, Error> {
@@ -175,13 +176,12 @@ mod test {
 
     #[test]
     fn evaluates_origin() {
-        let evaluated =
-            evaluate_expression("2 * (4 + 3)".into()).expect("Should parse successfully");
+        let evaluated = evaluate_expression("2 * (4 + 3)").expect("Should parse successfully");
         assert_eq!(evaluated, 14);
     }
 
     #[test]
     fn fails_for_negative_origin() {
-        evaluate_expression("-10".into()).expect_err("-10 should be an invalid origin");
+        evaluate_expression("-10").expect_err("-10 should be an invalid origin");
     }
 }

--- a/corewars-parser/src/phase/evaluation.rs
+++ b/corewars-parser/src/phase/evaluation.rs
@@ -14,7 +14,7 @@ use super::super::grammar;
 pub fn evaluate(lines: Vec<String>) -> Result<load_file::Instructions, Error> {
     let mut instructions = Vec::with_capacity(lines.len());
 
-    for line in lines.into_iter() {
+    for line in lines {
         if let Some(parse_result) = grammar::parse_line(&line)?.next() {
             match &parse_result.as_rule() {
                 grammar::Rule::Instruction => {
@@ -88,7 +88,7 @@ fn parse_instruction(
         // about this except for the introductory guide:
         // http://vyznev.net/corewar/guide.html#deep_instr
         // Basically just ported from the pMARS reference implementation: src/asm.c:1300
-        use load_file::Opcode::*;
+        use load_file::Opcode::{Dat, Jmp, Nop, Spl};
 
         match opcode {
             Dat => Ok(load_file::Instruction {
@@ -155,7 +155,7 @@ mod test {
             "jmp -1",
         ]
         .iter()
-        .map(|s| s.to_string())
+        .map(ToString::to_string)
         .collect();
 
         let expected_core = vec![

--- a/corewars-parser/src/phase/evaluation/expression.rs
+++ b/corewars-parser/src/phase/evaluation/expression.rs
@@ -123,7 +123,7 @@ fn evaluate_unary(pair: Pair) -> i32 {
 
     for inner_pair in pair.into_inner() {
         match inner_pair.as_rule() {
-            Rule::Number => result = Some(evaluate_number(inner_pair)),
+            Rule::Number => result = Some(evaluate_number(&inner_pair)),
             Rule::Expression => result = Some(evaluate(inner_pair)),
             Rule::UnaryOp => match inner_pair.as_str() {
                 "-" => unary_ops.push(|x| -x),
@@ -146,7 +146,7 @@ fn evaluate_unary(pair: Pair) -> i32 {
     result.unwrap_or_else(|| panic!("UnaryExpr did not contain a value"))
 }
 
-fn evaluate_number(pair: Pair) -> i32 {
+fn evaluate_number(pair: &Pair) -> i32 {
     assert!(pair.as_rule() == Rule::Number);
     pair.as_str()
         .parse::<i32>()
@@ -156,6 +156,8 @@ fn evaluate_number(pair: Pair) -> i32 {
 #[cfg(test)]
 mod test {
     use super::*;
+
+    use crate::grammar::parse_expression;
 
     use test_case::test_case;
 

--- a/corewars-parser/src/phase/evaluation/expression.rs
+++ b/corewars-parser/src/phase/evaluation/expression.rs
@@ -3,7 +3,7 @@
 //! Most functions here panic instead of returning Result because at this point
 //! any errors should have been caught earlier during initial parsing.
 
-use crate::grammar::*;
+use crate::grammar::{Pair, Rule};
 
 /// Evaluate an Expression. Panics if the expression tree is invalid, which
 /// should only happen due to programmer error (either the grammar or this code
@@ -139,7 +139,7 @@ fn evaluate_unary(pair: Pair) -> i32 {
         }
     }
 
-    for op in unary_ops.into_iter() {
+    for op in unary_ops {
         result = result.map(op);
     }
 

--- a/corewars-parser/src/phase/expansion.rs
+++ b/corewars-parser/src/phase/expansion.rs
@@ -6,6 +6,7 @@
 //! Labels used in the right-hand side of an expression substituted in-place.
 
 use std::collections::{HashMap, HashSet};
+use std::string::ToString;
 
 use pest::Span;
 
@@ -280,7 +281,7 @@ fn substitute_offsets(lines: &mut Vec<String>, labels: &Labels) {
 fn substitute_offsets_in_line(line: &mut String, labels: &Labels, from_offset: u32) {
     let tokenized_line = grammar::tokenize(line);
 
-    for token in tokenized_line.iter() {
+    for token in &tokenized_line {
         if token.as_rule() == grammar::Rule::Label {
             let label_value = labels.get(token.as_str());
 
@@ -380,7 +381,7 @@ impl Collector {
         let mut result = HashMap::new();
 
         let pending_labels = std::mem::take(&mut self.pending_labels);
-        for pending_label in pending_labels.into_iter() {
+        for pending_label in pending_labels {
             result.insert(pending_label, LabelValue::AbsoluteOffset(offset));
         }
 
@@ -469,7 +470,7 @@ mod test {
     use test_case::test_case;
 
     use super::*;
-    use LabelValue::*;
+    use LabelValue::{AbsoluteOffset, Substitution};
 
     #[test]
     fn collects_equ() {
@@ -572,7 +573,7 @@ mod test {
 
         let substitution = substitution
             .iter()
-            .map(|s| s.to_string())
+            .map(ToString::to_string)
             .collect::<Vec<String>>();
 
         let mut lines = vec![line.to_string()];
@@ -645,10 +646,10 @@ mod test {
         "label with expansion"
     )]
     fn collects_and_expands_labels(lines: &[&str], expected: Labels) {
-        let mut lines = lines.iter().map(|s| s.to_string()).collect();
+        let mut lines = lines.iter().map(ToString::to_string).collect();
         let result = collect_and_expand(&mut lines);
 
-        for (k, v) in expected.iter() {
+        for (k, v) in &expected {
             assert_eq!(Some(v), result.get(k));
         }
     }
@@ -805,10 +806,10 @@ mod test {
         "expand expr labels"
     )]
     fn collects_and_expands_forrof(lines: &[&str], expected: &[&str]) {
-        let mut lines = lines.iter().map(|s| s.to_string()).collect();
+        let mut lines = lines.iter().map(ToString::to_string).collect();
         let _ = collect_and_expand(&mut lines);
 
-        let expected_lines: Vec<String> = expected.iter().map(|s| s.to_string()).collect();
+        let expected_lines: Vec<String> = expected.iter().map(ToString::to_string).collect();
 
         assert_eq!(lines, expected_lines);
     }
@@ -907,8 +908,8 @@ mod test {
         "expand default labels"
     )]
     fn expands_substitutions(lines: &[&str], expected: &[&str]) {
-        let lines = lines.iter().map(|s| s.to_string()).collect();
-        let expected: Vec<String> = expected.iter().map(|s| s.to_string()).collect();
+        let lines = lines.iter().map(ToString::to_string).collect();
+        let expected: Vec<String> = expected.iter().map(ToString::to_string).collect();
 
         assert_eq!(
             Lines {
@@ -985,8 +986,8 @@ mod test {
         origin: Option<String>,
         expected_origin: Option<String>,
     ) {
-        let lines = lines.iter().map(|s| s.to_string()).collect();
-        let expected: Vec<String> = expected_lines.iter().map(|s| s.to_string()).collect();
+        let lines = lines.iter().map(ToString::to_string).collect();
+        let expected: Vec<String> = expected_lines.iter().map(ToString::to_string).collect();
 
         assert_eq!(
             expand(lines, origin),

--- a/corewars-sim/src/core.rs
+++ b/corewars-sim/src/core.rs
@@ -53,6 +53,7 @@ impl Core {
         })
     }
 
+    #[must_use]
     pub fn steps_taken(&self) -> usize {
         self.steps_taken
     }
@@ -70,11 +71,13 @@ impl Core {
     }
 
     /// Get the number of instructions in the core (available to programs via the `CORESIZE` label)
+    #[must_use]
     pub fn size(&self) -> u32 {
         self.instructions.len() as _
     }
 
     /// Get an instruction from a given index in the core
+    #[must_use]
     pub fn get(&self, index: i32) -> &Instruction {
         self.get_offset(self.offset(index))
     }

--- a/corewars-sim/src/core.rs
+++ b/corewars-sim/src/core.rs
@@ -1,6 +1,7 @@
 //! A [`Core`](Core) is a block of "memory" in which Redcode programs reside.
 //! This is where all simulation of a Core Wars battle takes place.
 
+use std::convert::TryInto;
 use std::fmt;
 use std::ops::{Index, Range};
 
@@ -67,13 +68,19 @@ impl Core {
     }
 
     fn offset<T: Into<i32>>(&self, value: T) -> Offset {
-        Offset::new(value.into(), self.size())
+        Offset::new(value.into(), self.len().try_into().unwrap())
     }
 
     /// Get the number of instructions in the core (available to programs via the `CORESIZE` label)
     #[must_use]
-    pub fn size(&self) -> u32 {
-        self.instructions.len() as _
+    pub fn len(&self) -> usize {
+        self.instructions.len()
+    }
+
+    /// Whether the core is empty or not (almost always `false`)
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.instructions.is_empty()
     }
 
     /// Get an instruction from a given index in the core
@@ -100,7 +107,7 @@ impl Core {
     /// Write an instruction at a given index into the core
     #[cfg(test)]
     fn set(&mut self, index: i32, value: Instruction) {
-        self.set_offset(self.offset(index), value)
+        self.set_offset(self.offset(index), value);
     }
 
     /// Write an instruction at a given offset into the core
@@ -112,7 +119,7 @@ impl Core {
     /// Load a [`Warrior`](Warrior) into the core starting at the front (first instruction of the core).
     /// Returns an error if the Warrior was too long to fit in the core, or had unresolved labels
     pub fn load_warrior(&mut self, warrior: &Warrior) -> Result<(), Error> {
-        if warrior.len() > self.size() {
+        if warrior.len() > self.len() {
             return Err(Error::WarriorTooLong);
         }
 
@@ -217,7 +224,7 @@ impl Core {
     }
 
     /// Run a core to completion. Return value determines whether the core resulted
-    /// in a tie (Ok) or something cause the warrior to stop executing (ExecutionError)
+    /// in a tie (Ok) or something cause the warrior to stop executing ([`process::Error`])
     pub fn run<T: Into<Option<usize>>>(&mut self, max_cycles: T) -> Result<(), process::Error> {
         let max_cycles = max_cycles.into().unwrap_or(DEFAULT_MAXCYCLES);
 
@@ -251,7 +258,7 @@ impl Core {
                     instruction_prefix(j, instruction)
                         + &instruction.to_string()
                         + &instruction_suffix(j, instruction),
-                )
+                );
             };
 
             if *instruction == Instruction::default() {
@@ -341,7 +348,7 @@ mod tests {
     #[test]
     fn new_core() {
         let core = Core::new(128).unwrap();
-        assert_eq!(core.size(), 128);
+        assert_eq!(core.len(), 128);
     }
 
     #[test]
@@ -358,8 +365,10 @@ mod tests {
         .expect("Failed to parse warrior");
 
         core.load_warrior(&warrior).expect("Failed to load warrior");
-        let expected_core_size = 128_i32;
-        assert_eq!(core.size(), expected_core_size as u32);
+        let expected_core_size = 128_usize;
+        assert_eq!(core.len(), expected_core_size);
+
+        let jmp_target = (expected_core_size - 1).try_into().unwrap();
 
         assert_eq!(
             &core.instructions[..4],
@@ -367,12 +376,12 @@ mod tests {
                 Instruction::new(Opcode::Mov, Field::direct(1), Field::immediate(1)),
                 Instruction::new(
                     Opcode::Jmp,
-                    Field::immediate(expected_core_size - 1),
+                    Field::immediate(jmp_target),
                     Field::immediate(2)
                 ),
                 Instruction::new(
                     Opcode::Jmp,
-                    Field::immediate(expected_core_size - 1),
+                    Field::immediate(jmp_target),
                     Field::immediate(2)
                 ),
                 Instruction::default(),
@@ -391,21 +400,21 @@ mod tests {
                 ],
                 origin: None,
             },
-            ..Default::default()
+            ..Warrior::default()
         };
 
         core.load_warrior(&warrior)
             .expect_err("Should have failed to load warrior: too long");
 
-        assert_eq!(core.size(), 128);
+        assert_eq!(core.len(), 128);
     }
 
     #[test]
     fn wrap_program_counter_on_overflow() {
         let mut core = build_core("mov $0, $1");
 
-        for i in 0..core.size() {
-            assert_eq!(core.program_counter().value(), i);
+        for i in 0..core.len() {
+            assert_eq!(core.program_counter().value() as usize, i);
             core.step().unwrap();
         }
 

--- a/corewars-sim/src/core/address.rs
+++ b/corewars-sim/src/core/address.rs
@@ -23,7 +23,10 @@ pub fn resolve_b_pointer(core: &Core, program_counter: Offset) -> Offset {
 }
 
 fn resolve_pointer(core: &Core, program_counter: Offset, field: &Field) -> Offset {
-    use AddressMode::*;
+    use AddressMode::{
+        Direct, Immediate, IndirectA, IndirectB, PostIncIndirectA, PostIncIndirectB,
+        PreDecIndirectA, PreDecIndirectB,
+    };
 
     let address_mode = field.address_mode;
     let field_value = field.unwrap_value();
@@ -58,7 +61,7 @@ pub fn apply_b_pointer(core: &mut Core, program_counter: Offset, eval_time: Eval
 }
 
 fn apply_pointer(core: &mut Core, program_counter: Offset, field: &Field, eval_time: EvalTime) {
-    use AddressMode::*;
+    use AddressMode::{PostIncIndirectA, PostIncIndirectB, PreDecIndirectA, PreDecIndirectB};
 
     let address_mode = field.address_mode;
     let pointer_location = program_counter + field.unwrap_value();

--- a/corewars-sim/src/core/address.rs
+++ b/corewars-sim/src/core/address.rs
@@ -70,13 +70,13 @@ fn apply_pointer(core: &mut Core, program_counter: Offset, field: &Field, eval_t
     let a_value = core.offset(pointed_to.a_field.unwrap_value());
     let b_value = core.offset(pointed_to.b_field.unwrap_value());
 
-    let pointed_to = core.get_offset_mut(pointer_location);
+    let mut_pointed_to = core.get_offset_mut(pointer_location);
 
     match (eval_time, address_mode) {
-        (EvalTime::Pre, PreDecIndirectA) => pointed_to.a_field.set_value(a_value - 1),
-        (EvalTime::Pre, PreDecIndirectB) => pointed_to.b_field.set_value(b_value - 1),
-        (EvalTime::Post, PostIncIndirectA) => pointed_to.a_field.set_value(a_value + 1),
-        (EvalTime::Post, PostIncIndirectB) => pointed_to.b_field.set_value(b_value + 1),
+        (EvalTime::Pre, PreDecIndirectA) => mut_pointed_to.a_field.set_value(a_value - 1),
+        (EvalTime::Pre, PreDecIndirectB) => mut_pointed_to.b_field.set_value(b_value - 1),
+        (EvalTime::Post, PostIncIndirectA) => mut_pointed_to.a_field.set_value(a_value + 1),
+        (EvalTime::Post, PostIncIndirectB) => mut_pointed_to.b_field.set_value(b_value + 1),
         _ => {}
     }
 }

--- a/corewars-sim/src/core/modifier.rs
+++ b/corewars-sim/src/core/modifier.rs
@@ -56,7 +56,7 @@ impl<'a> Executor<'a> {
     where
         FieldOp: FnMut(Offset, Offset) -> Option<Offset>,
     {
-        self.run_on_instructions::<_, fn(_, _) -> _, _>(field_op, None)
+        self.run_on_instructions::<_, fn(_, _) -> _, _>(field_op, None);
     }
 
     /// Execute a given operation (`FieldOp`) on a given instruction.

--- a/corewars-sim/src/core/opcode.rs
+++ b/corewars-sim/src/core/opcode.rs
@@ -15,6 +15,8 @@ pub struct Executed {
 }
 
 /// TODO: docstring
+// TODO
+#[allow(clippy::too_many_lines)]
 pub fn execute(core: &mut Core, program_counter: Offset) -> Result<Executed, process::Error> {
     let instruction = core.get_offset(program_counter).clone();
     let opcode = instruction.opcode;
@@ -76,7 +78,7 @@ pub fn execute(core: &mut Core, program_counter: Offset) -> Result<Executed, pro
             executor.run_on_instructions(
                 |a, b| {
                     if a != b {
-                        program_counter_offset.set(None)
+                        program_counter_offset.set(None);
                     }
                     None
                 },
@@ -87,7 +89,7 @@ pub fn execute(core: &mut Core, program_counter: Offset) -> Result<Executed, pro
                     }
                     None
                 },
-            )
+            );
         }
         Opcode::Slt => {
             program_counter_offset.set(skip_one.into());
@@ -96,7 +98,7 @@ pub fn execute(core: &mut Core, program_counter: Offset) -> Result<Executed, pro
                     program_counter_offset.set(None);
                 }
                 None
-            })
+            });
         }
         Opcode::Sne => {
             let next_instruction = Some(skip_one);
@@ -113,7 +115,7 @@ pub fn execute(core: &mut Core, program_counter: Offset) -> Result<Executed, pro
                     }
                     None
                 },
-            )
+            );
         }
 
         // Jumping control flow opcodes
@@ -213,8 +215,8 @@ mod tests {
                 &vec![
                     instruction.clone(),
                     instruction,
-                    Default::default(),
-                    Default::default(),
+                    Instruction::default(),
+                    Instruction::default(),
                 ][..]
             );
         }
@@ -310,25 +312,25 @@ mod tests {
             assert_eq!(
                 *core.get(2),
                 Instruction::new(Opcode::Dat, Field::immediate(2), Field::immediate(3)),
-            )
+            );
         }
 
         #[test_case(
             Instruction::new(Opcode::Dat, Field::direct(0), Field::direct(2)),
-            Instruction::new(Opcode::Dat, Field::direct(0), Field::direct(3))
+            &Instruction::new(Opcode::Dat, Field::direct(0), Field::direct(3))
             ; "a_zero"
         )]
         #[test_case(
             Instruction::new(Opcode::Dat, Field::direct(2), Field::direct(0)),
-            Instruction::new(Opcode::Dat, Field::direct(2), Field::direct(0))
+            &Instruction::new(Opcode::Dat, Field::direct(2), Field::direct(0))
             ; "b_zero"
         )]
         #[test_case(
             Instruction::new(Opcode::Dat, Field::direct(0), Field::direct(0)),
-            Instruction::new(Opcode::Dat, Field::direct(0), Field::direct(0))
+            &Instruction::new(Opcode::Dat, Field::direct(0), Field::direct(0))
             ; "both_zero"
         )]
-        fn execute_div_by_zero(divisor: Instruction, result: Instruction) {
+        fn execute_div_by_zero(divisor: Instruction, result: &Instruction) {
             use pretty_assertions::assert_eq;
 
             let mut core = build_core(
@@ -343,7 +345,7 @@ mod tests {
             let err = execute(&mut core, pc).unwrap_err();
 
             assert_eq!(err, Error::DivideByZero);
-            assert_eq!(core.get(2), &result)
+            assert_eq!(core.get(2), result);
         }
 
         #[test]
@@ -362,25 +364,25 @@ mod tests {
             assert_eq!(
                 *core.get(2),
                 Instruction::new(Opcode::Dat, Field::immediate(0), Field::immediate(1)),
-            )
+            );
         }
 
         #[test_case(
             Instruction::new(Opcode::Dat, Field::direct(0), Field::direct(4)),
-            Instruction::new(Opcode::Dat, Field::direct(0), Field::direct(2))
+            &Instruction::new(Opcode::Dat, Field::direct(0), Field::direct(2))
             ; "a_zero"
         )]
         #[test_case(
             Instruction::new(Opcode::Dat, Field::direct(3), Field::direct(0)),
-            Instruction::new(Opcode::Dat, Field::direct(1), Field::direct(0))
+            &Instruction::new(Opcode::Dat, Field::direct(1), Field::direct(0))
             ; "b_zero"
         )]
         #[test_case(
             Instruction::new(Opcode::Dat, Field::direct(0), Field::direct(0)),
-            Instruction::new(Opcode::Dat, Field::direct(0), Field::direct(0))
+            &Instruction::new(Opcode::Dat, Field::direct(0), Field::direct(0))
             ; "both_zero"
         )]
-        fn execute_mod_by_zero(divisor: Instruction, result: Instruction) {
+        fn execute_mod_by_zero(divisor: Instruction, result: &Instruction) {
             use pretty_assertions::assert_eq;
 
             let mut core = build_core(
@@ -395,7 +397,7 @@ mod tests {
             let err = execute(&mut core, pc).unwrap_err();
 
             assert_eq!(err, Error::DivideByZero);
-            assert_eq!(core.get(2), &result)
+            assert_eq!(core.get(2), result);
         }
     }
 
@@ -618,9 +620,9 @@ mod tests {
                 &core.instructions[1..5],
                 &vec![
                     Instruction::new(Opcode::Jmp, Field::direct(3), Field::immediate(0)),
-                    Default::default(),
-                    Default::default(),
-                    Default::default()
+                    Instruction::default(),
+                    Instruction::default(),
+                    Instruction::default()
                 ][..]
             );
         }
@@ -642,9 +644,9 @@ mod tests {
                 &core.instructions[1..5],
                 &vec![
                     Instruction::new(Opcode::Spl, Field::direct(3), Field::immediate(0)),
-                    Default::default(),
-                    Default::default(),
-                    Default::default()
+                    Instruction::default(),
+                    Instruction::default(),
+                    Instruction::default()
                 ][..]
             );
         }

--- a/corewars-sim/src/lib.rs
+++ b/corewars-sim/src/lib.rs
@@ -1,3 +1,7 @@
+// TODO(#43)
+#![allow(clippy::missing_errors_doc)]
+#![allow(clippy::missing_panics_doc)]
+
 // Public modules
 mod core;
 

--- a/corewars-sim/tests/dump_test.rs
+++ b/corewars-sim/tests/dump_test.rs
@@ -22,9 +22,10 @@ fn read_dir(input_file: &str) {
 
     let expected_out_file = PathBuf::from(input_file.replace("input", "expected_output"));
 
-    let expected_output = fs::read_to_string(&expected_out_file)
-        .map(|s| normalized(s.trim().chars()).collect::<String>())
-        .unwrap_or_else(|err| panic!("Unable to read file {:?}: {:?}", input_file, err));
+    let expected_output = fs::read_to_string(&expected_out_file).map_or_else(
+        |err| panic!("Unable to read file {:?}: {:?}", input_file, err),
+        |s| normalized(s.trim().chars()).collect::<String>(),
+    );
 
     let parsed_warrior = match corewars_parser::parse(&input) {
         ParseResult::Ok(core, _) => core,

--- a/corewars/src/cli.rs
+++ b/corewars/src/cli.rs
@@ -122,6 +122,6 @@ pub fn run() -> Result<(), Box<dyn Error>> {
 
 fn print_warnings(warnings: &[parser::Warning]) {
     for warning in warnings.iter() {
-        eprintln!("Warning: {}", warning)
+        eprintln!("Warning: {}", warning);
     }
 }

--- a/corewars/src/lib.rs
+++ b/corewars/src/lib.rs
@@ -1,2 +1,6 @@
+// TODO(#43)
+#![allow(clippy::missing_errors_doc)]
+#![allow(clippy::missing_panics_doc)]
+
 // Public modules
 pub mod cli;

--- a/corewars/tests/cli_test.rs
+++ b/corewars/tests/cli_test.rs
@@ -55,7 +55,7 @@ fn dump_stdout() {
         .assert()
         .success();
 
-    let out_text = cmd.get_output().stdout.to_owned();
+    let out_text = cmd.get_output().stdout.clone();
 
     let file_contents: String = normalized(String::from_utf8(out_text).unwrap().chars()).collect();
     assert_eq!(file_contents, &**EXPECTED_OUT);


### PR DESCRIPTION
Closes #74 

Exceptions:
- Docs-related lints, which will are tracked in #43
- Cast-related lints (mostly i32 <-> u32), which will be tracked in a
  new issue